### PR TITLE
[ML] Add correlation tooltip

### DIFF
--- a/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations.tsx
@@ -236,7 +236,7 @@ export function MlLatencyCorrelations({ onClose }: Props) {
               'xpack.apm.correlations.latencyCorrelations.correlationsTable.correlationColumnDescription',
               {
                 defaultMessage:
-                  'A score between -1 and 1 for the relative impact on latency.',
+                  'The impact of a field on the latency of the service, ranging from 0 to 1.',
               }
             )}
           >

--- a/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations.tsx
@@ -18,6 +18,7 @@ import {
   EuiSpacer,
   EuiText,
   EuiTitle,
+  EuiToolTip,
   EuiHorizontalRule,
 } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
@@ -229,9 +230,31 @@ export function MlLatencyCorrelations({ onClose }: Props) {
       {
         width: '116px',
         field: 'correlation',
-        name: i18n.translate(
-          'xpack.apm.correlations.latencyCorrelations.correlationsTable.correlationLabel',
-          { defaultMessage: 'Correlation' }
+        name: (
+          <EuiToolTip
+            content={i18n.translate(
+              'xpack.apm.correlations.latencyCorrelations.correlationsTable.correlationColumnDescription',
+              {
+                defaultMessage:
+                  'A score between -1 and 1 for the relative impact on latency.',
+              }
+            )}
+          >
+            <>
+              {i18n.translate(
+                'xpack.apm.correlations.latencyCorrelations.correlationsTable.correlationLabel',
+                {
+                  defaultMessage: 'Correlation',
+                }
+              )}{' '}
+              <EuiIcon
+                size="s"
+                color="subdued"
+                type="questionInCircle"
+                className="eui-alignTop"
+              />
+            </>
+          </EuiToolTip>
         ),
         render: (_: any, term: MlCorrelationsTerms) => {
           return <div>{asPreciseDecimal(term.correlation, 2)}</div>;


### PR DESCRIPTION
## Summary

Adds a tooltip for the new Correlation column in https://github.com/elastic/kibana/pull/99905

### Screenshot

![image](https://user-images.githubusercontent.com/26471269/123691141-18aa0400-d80a-11eb-912a-35a47800f274.png)
