### PR TITLE
[ML] APM latency correlations popover

### DIFF
--- a/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations.tsx
@@ -264,22 +264,7 @@ export function MlLatencyCorrelations({ onClose }: Props) {
 
   return (
     <>
-      <EuiText size="s" color="subdued">
-        <p>
-          {i18n.translate(
-            'xpack.apm.correlations.latencyCorrelations.description',
-            {
-              defaultMessage:
-                'What is slowing down my service? Correlations will help discover a slower performance in a particular cohort of your data.',
-            }
-          )}
-        </p>
-      </EuiText>
-      <EuiFlexItem grow={false}>
-        <LatencyCorrelationsHelpPopover />
-      </EuiFlexItem>
       <EuiSpacer size="m" />
-
       <EuiFlexGroup>
         <EuiFlexItem grow={false}>
           {!isRunning && (
@@ -322,6 +307,9 @@ export function MlLatencyCorrelations({ onClose }: Props) {
               />
             </EuiFlexItem>
           </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <LatencyCorrelationsHelpPopover />
         </EuiFlexItem>
       </EuiFlexGroup>
 

--- a/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations.tsx
@@ -36,6 +36,7 @@ import { useCorrelations } from './use_correlations';
 import { push } from '../../shared/Links/url_helpers';
 import { useUiTracker } from '../../../../../observability/public';
 import { asPreciseDecimal } from '../../../../common/utils/formatters';
+import { LatencyCorrelationsHelpPopover } from './ml_latency_correlations_help_popover';
 
 const DEFAULT_PERCENTILE_THRESHOLD = 95;
 const isErrorMessage = (arg: unknown): arg is Error => {
@@ -274,7 +275,9 @@ export function MlLatencyCorrelations({ onClose }: Props) {
           )}
         </p>
       </EuiText>
-
+      <EuiFlexItem grow={false}>
+        <LatencyCorrelationsHelpPopover />
+      </EuiFlexItem>
       <EuiSpacer size="m" />
 
       <EuiFlexGroup>

--- a/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations_help_popover.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations_help_popover.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState } from 'react';
+import { i18n } from '@kbn/i18n';
+import { FormattedMessage } from '@kbn/i18n/react';
+import { HelpPopover, HelpPopoverButton } from '../help_popover/help_popover';
+
+export function LatencyCorrelationsHelpPopover() {
+  const [isPopoverOpen, setIsPopoverOpen] = useState(false);
+
+  return (
+    <HelpPopover
+      anchorPosition="upCenter"
+      button={
+        <HelpPopoverButton
+          onClick={() => {
+            setIsPopoverOpen(!isPopoverOpen);
+          }}
+        />
+      }
+      closePopover={() => setIsPopoverOpen(false)}
+      isOpen={isPopoverOpen}
+      title={i18n.translate('xpack.apm.correlations.latencyPopoverTitle', {
+        defaultMessage: 'Latency correlations',
+      })}
+    >
+      <p>
+        <FormattedMessage
+          id="xpack.apm.correlations.latencyPopoverBasicExplanation"
+          defaultMessage="Correlations help you discover which fields are contributing to increased service response times or latency."
+        />
+      </p>
+    </HelpPopover>
+  );
+}

--- a/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations_help_popover.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations_help_popover.tsx
@@ -15,7 +15,7 @@ export function LatencyCorrelationsHelpPopover() {
 
   return (
     <HelpPopover
-      anchorPosition="upCenter"
+      anchorPosition="leftUp"
       button={
         <HelpPopoverButton
           onClick={() => {

--- a/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations_help_popover.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations_help_popover.tsx
@@ -35,6 +35,24 @@ export function LatencyCorrelationsHelpPopover() {
           defaultMessage="Correlations help you discover which fields are contributing to increased service response times or latency."
         />
       </p>
+      <p>
+        <FormattedMessage
+          id="xpack.apm.correlations.latencyPopoverChartExplanation"
+          defaultMessage="The latency distribution chart visualizes the overall latency of the service and the attributes that are most likely responsible for slow transactions. You can view the impact of other attributes by selecting them in the table."
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="xpack.apm.correlations.latencyPopoverTableExplanation"
+          defaultMessage="The table is sorted by correlation values, which are derived by using a combination of Pearson correlation coefficient (PCC) and Kolmogorov–Smirnov (K-S) tests and range from 0 to 1. Attributes with a high correlation are likely to contribute to increased latency."
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="xpack.apm.correlations.latencyPopoverFilterExplanation"
+          defaultMessage="You can also add or remove filters to affect the queries in the APM app."
+        />
+      </p>
     </HelpPopover>
   );
 }

--- a/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations_help_popover.tsx
+++ b/x-pack/plugins/apm/public/components/app/correlations/ml_latency_correlations_help_popover.tsx
@@ -38,13 +38,13 @@ export function LatencyCorrelationsHelpPopover() {
       <p>
         <FormattedMessage
           id="xpack.apm.correlations.latencyPopoverChartExplanation"
-          defaultMessage="The latency distribution chart visualizes the overall latency of the service and the attributes that are most likely responsible for slow transactions. You can view the impact of other attributes by selecting them in the table."
+          defaultMessage="The latency distribution chart visualizes the overall latency of the service. When you hover over attributes in the table, their latency distribution is added to the chart."
         />
       </p>
       <p>
         <FormattedMessage
           id="xpack.apm.correlations.latencyPopoverTableExplanation"
-          defaultMessage="The table is sorted by correlation values, which are derived by using a combination of Pearson correlation coefficient (PCC) and Kolmogorov–Smirnov (K-S) tests and range from 0 to 1. Attributes with a high correlation are likely to contribute to increased latency."
+          defaultMessage="The table is sorted by correlation values, which are Pearson correlation coefficients (PCC) that range from 0 to 1. A Kolmogorov–Smirnov (K-S) test is used to verify that the impact is statistically significant. Attributes with a high correlation are likely to contribute to increased latency."
         />
       </p>
       <p>

--- a/x-pack/plugins/apm/public/components/app/help_popover/help_popover.scss
+++ b/x-pack/plugins/apm/public/components/app/help_popover/help_popover.scss
@@ -1,0 +1,9 @@
+.apmHelpPopover__panel {
+  max-width: $euiSize * 30;
+}
+
+.apmHelpPopover__content {
+  @include euiYScrollWithShadows;
+  max-height: 40vh;
+  padding: $euiSizeS;
+}

--- a/x-pack/plugins/apm/public/components/app/help_popover/help_popover.tsx
+++ b/x-pack/plugins/apm/public/components/app/help_popover/help_popover.tsx
@@ -26,6 +26,7 @@ export function HelpPopoverButton({
       className="apmHelpPopover__buttonIcon"
       size="s"
       iconType="help"
+      aria-label="Help"
       onClick={onClick}
     />
   );

--- a/x-pack/plugins/apm/public/components/app/help_popover/help_popover.tsx
+++ b/x-pack/plugins/apm/public/components/app/help_popover/help_popover.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { ReactNode } from 'react';
+import {
+  EuiButtonIcon,
+  EuiLinkButtonProps,
+  EuiPopover,
+  EuiPopoverProps,
+  EuiPopoverTitle,
+  EuiText,
+} from '@elastic/eui';
+import './help_popover.scss';
+
+export function HelpPopoverButton({
+  onClick,
+}: {
+  onClick: EuiLinkButtonProps['onClick'];
+}) {
+  return (
+    <EuiButtonIcon
+      className="apmHelpPopover__buttonIcon"
+      size="s"
+      iconType="help"
+      onClick={onClick}
+    />
+  );
+}
+
+export function HelpPopover({
+  anchorPosition,
+  button,
+  children,
+  closePopover,
+  isOpen,
+  title,
+}: {
+  anchorPosition?: EuiPopoverProps['anchorPosition'];
+  button: EuiPopoverProps['button'];
+  children: ReactNode;
+  closePopover: EuiPopoverProps['closePopover'];
+  isOpen: EuiPopoverProps['isOpen'];
+  title?: string;
+}) {
+  return (
+    <EuiPopover
+      anchorPosition={anchorPosition}
+      button={button}
+      className="apmHelpPopover"
+      closePopover={closePopover}
+      isOpen={isOpen}
+      ownFocus
+      panelClassName="apmHelpPopover__panel"
+      panelPaddingSize="none"
+    >
+      {title && <EuiPopoverTitle paddingSize="s">{title}</EuiPopoverTitle>}
+
+      <EuiText className="apmHelpPopover__content" size="s">
+        {children}
+      </EuiText>
+    </EuiPopover>
+  );
+}

--- a/x-pack/plugins/apm/public/components/app/help_popover/index.tsx
+++ b/x-pack/plugins/apm/public/components/app/help_popover/index.tsx
@@ -1,0 +1,8 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+export { HelpPopoverButton, HelpPopover } from './help_popover';


### PR DESCRIPTION
## Summary

This PR is based on https://github.com/elastic/kibana/pull/99905

It adds an [EuiPopover](https://elastic.github.io/eui/#/layout/popover) similar to how they were added in [Lens](https://github.com/elastic/kibana/blob/master/x-pack/plugins/lens/public/indexpattern_datasource/help_popover.tsx) and contains content similar to what was originally written in the [Kibana guide](https://www.elastic.co/guide/en/kibana/master/correlations.html).

### Screenshots

![image](https://user-images.githubusercontent.com/26471269/123855638-fc26ce00-d8d4-11eb-9bf7-13b4c17c3197.png)

